### PR TITLE
separate anchor for human-supplied or term-name-calculated ids, from …

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,3 +1,3 @@
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "features/termsource-to-source"
-gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "features/termsource-to-source"
-gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "features/termsource-to-source"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "features/anchor"
+gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "features/anchor"

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,3 +1,4 @@
 gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
+gem "metanorma-utils", git: "https://github.com/metanorma/metanorma-utils", branch: "main"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "features/anchor"
 gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "features/anchor"

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,4 +1,4 @@
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "features/anchor"
 gem "metanorma-utils", git: "https://github.com/metanorma/metanorma-utils", branch: "main"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "features/anchor"
 gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "features/anchor"

--- a/lib/metanorma/jis/isodoc.rng
+++ b/lib/metanorma/jis/isodoc.rng
@@ -687,6 +687,20 @@ titlecase, or lowercase</a:documentation>
       </attribute>
     </optional>
   </define>
+  <define name="RequiredId" combine="interleave">
+    <optional>
+      <attribute name="anchor">
+        <a:documentation> User-supplied anchor of element; replaced by content-based id, with all references to the anchor updated accordingly</a:documentation>
+      </attribute>
+    </optional>
+  </define>
+  <define name="OptionalId" combine="interleave">
+    <optional>
+      <attribute name="anchor">
+        <a:documentation> User-supplied anchor of element; replaced by content-based id, with all references to the anchor updated accordingly</a:documentation>
+      </attribute>
+    </optional>
+  </define>
   <define name="ObligationType">
     <a:documentation>The force of a clause in a standard document: whether it has normative or informative effect</a:documentation>
     <choice>

--- a/lib/metanorma/jis/processor.rb
+++ b/lib/metanorma/jis/processor.rb
@@ -46,13 +46,17 @@ module Metanorma
         options_preprocess(options)
         case format
         when :html
-          IsoDoc::Jis::HtmlConvert.new(options).convert(inname, xml, nil, outname)
+          IsoDoc::Jis::HtmlConvert.new(options)
+            .convert(inname, xml, nil, outname)
         when :doc
-          IsoDoc::Jis::WordConvert.new(options).convert(inname, xml, nil, outname)
+          IsoDoc::Jis::WordConvert.new(options)
+            .convert(inname, xml, nil, outname)
         when :pdf
-          IsoDoc::Jis::PdfConvert.new(options).convert(inname, xml, nil, outname)
+          IsoDoc::Jis::PdfConvert.new(options)
+            .convert(inname, xml, nil, outname)
         when :presentation
-          IsoDoc::Jis::PresentationXMLConvert.new(options).convert(inname, xml, nil, outname)
+          IsoDoc::Jis::PresentationXMLConvert.new(options)
+            .convert(inname, xml, nil, outname)
         else
           super
         end

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -900,10 +900,10 @@ RSpec.describe Metanorma::Jis do
         #{BOILERPLATE}
         <sections></sections>
                  <bibliography>
-             <references id="_" normative="true" obligation="informative">
+             <references id="_" anchor="_normative_references" normative="true" obligation="informative">
                <title>引用規格</title>
                <p id="_">This is extraneous information</p>
-               <bibitem id="iso216" type="standard">
+               <bibitem id="_" anchor="iso216" type="standard">
                  <title format="text/plain">Reference</title>
                  <docidentifier>ISO 216</docidentifier>
                  <docnumber>216</docnumber>
@@ -976,19 +976,19 @@ RSpec.describe Metanorma::Jis do
           #{BLANK_HDR}
       #{BOILERPLATE}
             <sections>
-        <clause id="_" inline-header="false" obligation="normative">
+        <clause id="_" anchor="_clause" inline-header="false" obligation="normative">
           <title>Clause</title>
           <table id="_">
             <thead>
               <tr>
-                <th valign="top" align="left">A</th>
-                <th valign="top" align="left">B</th>
+                <th id="_" valign="top" align="left">A</th>
+                <th id="_" valign="top" align="left">B</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td valign="top" align="left">C</td>
-                <td valign="top" align="left">B</td>
+                <td id="_" valign="top" align="left">C</td>
+                <td id="_" valign="top" align="left">B</td>
               </tr>
             </tbody>
           <example id="_">
@@ -1050,19 +1050,19 @@ RSpec.describe Metanorma::Jis do
           #{BLANK_HDR}
       #{BOILERPLATE}
             <sections>
-        <clause id="_" inline-header="false" obligation="normative">
+        <clause id="_" anchor="_clause" inline-header="false" obligation="normative">
           <title>Clause</title>
           <table id="_">
             <thead>
               <tr>
-                <th valign="top" align="left">A</th>
-                <th valign="top" align="left">B</th>
+                <th id="_" valign="top" align="left">A</th>
+                <th id="_" valign="top" align="left">B</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td valign="top" align="left">C</td>
-                <td valign="top" align="left">B</td>
+                <td id="_" valign="top" align="left">C</td>
+                <td id="_" valign="top" align="left">B</td>
               </tr>
             </tbody>
           <example id="_">
@@ -1108,7 +1108,7 @@ RSpec.describe Metanorma::Jis do
       #{BLANK_HDR}
       #{BOILERPLATE}
                <sections>
-           <clause id="_" inline-header="false" obligation="normative">
+           <clause id="_" anchor="_clausenormal_flow" inline-header="false" obligation="normative">
              <title>
                Clause
                <fn reference="1">
@@ -1124,8 +1124,8 @@ RSpec.describe Metanorma::Jis do
                </name>
                <thead>
                  <tr>
-                   <th valign="top" align="left">A</th>
-                   <th valign="top" align="left">
+                   <th id="_" valign="top" align="left">A</th>
+                   <th id="_" valign="top" align="left">
                      B
                      <fn reference="b">
                        <p id="_">Second</p>
@@ -1135,8 +1135,8 @@ RSpec.describe Metanorma::Jis do
                </thead>
                <tbody>
                  <tr>
-                   <td valign="top" align="left">C</td>
-                   <td valign="top" align="left">
+                   <td id="_" valign="top" align="left">C</td>
+                   <td id="_" valign="top" align="left">
                      B
                      <fn reference="c">
                        <p id="_">Third</p>
@@ -1173,10 +1173,10 @@ RSpec.describe Metanorma::Jis do
       #{BLANK_HDR}
       #{BOILERPLATE}
       <sections/>
-        <annex id="_" inline-header="false" obligation="normative">
+        <annex id="_" anchor="_first_appendix" inline-header="false" obligation="normative">
           <title>First appendix</title>
         </annex>
-        <annex id="_" commentary="true" inline-header="false" obligation="informative">
+        <annex id="_" anchor="_commentary" commentary="true" inline-header="false" obligation="informative">
           <title>Commentary</title>
         </annex>
       </metanorma>

--- a/spec/metanorma/processor_spec.rb
+++ b/spec/metanorma/processor_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Metanorma::Jis::Processor do
       #{BLANK_HDR}
       #{BOILERPLATE}
       <sections>
-          <clause id="_" inline-header="false" obligation="normative">
+          <clause id="_" anchor="_clause" inline-header="false" obligation="normative">
             <title>Clause</title>
           </clause>
         </sections>

--- a/spec/metanorma/refs_spec.rb
+++ b/spec/metanorma/refs_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Metanorma::Jis do
     INPUT
 
     out = Nokogiri::XML(Asciidoctor.convert(input, *OPTIONS))
-    expect(out.xpath("//xmlns:references/xmlns:bibitem/@id")
+    expect(out.xpath("//xmlns:references/xmlns:bibitem/@anchor")
       .map(&:value))
       .to be_equivalent_to ["ref11", "ref2", "ref1", "ref3", "ref5", "ref4",
                             "ref6", "ref8", "ref7", "ref9", "ref10"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,7 @@ end
 
 def strip_guid(xml)
   xml.gsub(%r{ id="_[^"]+"}, ' id="_"')
+    .gsub(%r{ semx-id="[^"]*"}, '')
     .gsub(%r{ original-id="_[^"]+"}, ' original-id="_"')
     .gsub(%r{ target="_[^"]+"}, ' target="_"')
     .gsub(%r{ source="_[^"]+"}, ' source="_"')


### PR DESCRIPTION
…id for content ids: https://github.com/metanorma/metanorma-standoc/issues/1007

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
