### PR TITLE
Wire japanese_date to IsoDoc::ExtendedDateFormatter

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,3 +1,4 @@
+gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "feature/liquid-date-i18n-filter"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
 gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "main"
 gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"

--- a/lib/isodoc/jis/i18n-ja.yaml
+++ b/lib/isodoc/jis/i18n-ja.yaml
@@ -40,10 +40,10 @@ punct:
   biblio-terminator: ""
 date_format:
   default:
-    year:       "%EY{spellout}年"
-    year_month: "%EY{spellout}年%-m月"
-    full:       "%EY{spellout}年%-m月%-d日"
+    year:       "%EY[spellout]年"
+    year_month: "%EY[spellout]年%-m月"
+    full:       "%EY[spellout]年%-m月%-d日"
   japanese_numbering:
-    year:       "%EY{spellout}年"
-    year_month: "%EY{spellout}年%Om{spellout}月"
-    full:       "%EY{spellout}年%Om{spellout}月%Od{spellout}日"
+    year:       "%EY[spellout]年"
+    year_month: "%EY[spellout]年%Om[spellout]月"
+    full:       "%EY[spellout]年%Om[spellout]月%Od[spellout]日"

--- a/lib/isodoc/jis/i18n-ja.yaml
+++ b/lib/isodoc/jis/i18n-ja.yaml
@@ -31,10 +31,19 @@ doctype_dict:
 stage_dict:
   international-standard: 日本産業規格
 punct:
-  open-title: 
-  close-title: 
+  open-title:
+  close-title:
   open-secondary-title:
   close-secondary-title:
   # We need the trailing half-width space, to allow it to be converted to cjk-latin-separator if Latn text follows
   biblio-field-delimiter: "。 "
   biblio-terminator: ""
+date_format:
+  default:
+    year:       "%EY{spellout}年"
+    year_month: "%EY{spellout}年%-m月"
+    full:       "%EY{spellout}年%-m月%-d日"
+  japanese_numbering:
+    year:       "%EY{spellout}年"
+    year_month: "%EY{spellout}年%Om{spellout}月"
+    full:       "%EY{spellout}年%Om{spellout}月%Od{spellout}日"

--- a/lib/isodoc/jis/i18n.rb
+++ b/lib/isodoc/jis/i18n.rb
@@ -18,26 +18,21 @@ module IsoDoc
         end
       end
 
-      # use Japanese ordinals for era years
-      def japanese_date(date)
-        date.nil? and return date
+      def japanese_date(date, japanese_numbering: false)
+        return date if date.nil?
+
         d = date.split("-").map(&:to_i)
-        time = Date.new(*d)
-        yr = japanese_year(time)
-        case d.size
-        when 1 then yr
-        when 2 then yr + time.strftime("%-m月")
-        when 3 then yr + time.strftime("%-m月%-d日")
-        else date
-        end
+        fmt = japanese_date_format(d.size, japanese_numbering) or return date
+        IsoDoc::ExtendedDateFormatter.format(Date.new(*d), fmt, lang: "ja")
+      rescue StandardError
+        date
       end
 
-      def japanese_year(time)
-        era_yr = time.era_year.to_i.localize(:ja)
-          .to_rbnf_s("SpelloutRules", "spellout-numbering-year")
-        "#{time.strftime('%JN')}#{era_yr}年"
-      rescue StandardError
-        time.year.to_s
+      def japanese_date_format(arity, japanese_numbering)
+        return nil unless (1..3).cover?(arity)
+
+        branch = japanese_numbering ? "japanese_numbering" : "default"
+        @labels.dig("date_format", branch, %w[year year_month full][arity - 1])
       end
     end
   end

--- a/lib/isodoc/jis/presentation_xml_convert.rb
+++ b/lib/isodoc/jis/presentation_xml_convert.rb
@@ -74,12 +74,8 @@ module IsoDoc
       end
 
       def date_translate1(date)
-        j = @i18n.japanese_date(date.strip)
-        @autonumbering_style == :japanese and
-          j.gsub!(/(\d+)/) do
-            $1.to_i.localize(:ja).spellout
-          end
-        j
+        ja = @autonumbering_style == :japanese
+        @i18n.japanese_date(date.strip, japanese_numbering: ja)
       end
 
       def edition_integer?(bibdata)


### PR DESCRIPTION
See metanorma/metanorma-plateau#147 for the full narrative (strategic ticket — cross-repo refactor wiring metanorma-jis and metanorma-plateau to `IsoDoc::ExtendedDateFormatter` from `isodoc-i18n 1.5.0`).
