### PR TITLE
Delegate japanese_date to format_iso_date

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,5 +1,3 @@
-gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "feature/liquid-date-i18n-filter"
-gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "feature/format-iso-date-helper"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
 gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "main"
 gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,4 +1,5 @@
 gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "feature/liquid-date-i18n-filter"
+gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "feature/format-iso-date-helper"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
 gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "main"
 gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"

--- a/lib/isodoc/jis/i18n.rb
+++ b/lib/isodoc/jis/i18n.rb
@@ -19,20 +19,15 @@ module IsoDoc
       end
 
       def japanese_date(date, japanese_numbering: false)
-        return date if date.nil?
-
-        d = date.split("-").map(&:to_i)
-        fmt = japanese_date_format(d.size, japanese_numbering) or return date
-        IsoDoc::ExtendedDateFormatter.format(Date.new(*d), fmt, lang: "ja")
-      rescue StandardError
-        date
-      end
-
-      def japanese_date_format(arity, japanese_numbering)
-        return nil unless (1..3).cover?(arity)
-
         branch = japanese_numbering ? "japanese_numbering" : "default"
-        @labels.dig("date_format", branch, %w[year year_month full][arity - 1])
+        fmts = @labels.dig("date_format", branch) || {}
+        IsoDoc::ExtendedDateFormatter.format_iso_date(
+          date,
+          lang: "ja",
+          year: fmts["year"],
+          year_month: fmts["year_month"],
+          full: fmts["full"],
+        )
       end
     end
   end


### PR DESCRIPTION
Part of metanorma/metanorma-plateau#147 (Phase 3 — flavour-copies refactor to shared `format_iso_date` helper). Follow-up to #453 which wired `japanese_date` to `ExtendedDateFormatter.format`; this PR routes the same call through the new `format_iso_date` convenience wrapper added in metanorma/isodoc-i18n#24, eliminating the local arity-branching helper.
