### PR TITLE
opt out of docid annotation via annotate_docid? predicate: https://github.com/metanorma/metanorma-iso/issues/1236

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,2 @@
+gem "isodoc", github: "metanorma/isodoc", branch: "feature/hoist-docid-semantic-annotation"
+gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "fix/improved-pubid-annotation"

--- a/lib/isodoc/jis/init.rb
+++ b/lib/isodoc/jis/init.rb
@@ -24,8 +24,8 @@ module IsoDoc
           .merge(language: @lang, script: @script, i18nhash: @i18n.get))
       end
 
-      def std_docid_semantic(text)
-        text
+      def annotate_docid?(_id)
+        false
       end
 
       def convert_i18n_init1(docxml)


### PR DESCRIPTION
Replace JIS's no-op `def std_docid_semantic(text); text; end` stub in
`lib/isodoc/jis/init.rb` with `def annotate_docid?(_id); false; end`.

With the semantic-docidentifier-annotation orchestrator hoisted to the
shared `IsoDoc::PresentationXMLConvert` base, the predicate short-circuits
before any annotation runs. Identity behaviour preserved; a future PR can
flip the predicate to `true` once a JIS `std_docid_span_classes` override
is in place (Pubid::Jis is already bundled via the umbrella `pubid` gem).

`Gemfile.devel` pins both `isodoc` (base hoist) and `metanorma-iso` (ISO
refactor) to their PR branches. Both pins required to keep JIS specs from
inheriting ISO's pre-refactor `std_docid_semantic` from rubygems.

Companion PRs: metanorma/isodoc#795, metanorma/metanorma-iso#1546,
metanorma/metanorma-ieee#741, metanorma/metanorma-iec#527.

Tracking: https://github.com/metanorma/metanorma-iso/issues/1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
