### PR TITLE
Wrap commentary cross-reference titles in <semx element='title'>

### DIFF
--- a/lib/isodoc/jis/xref.rb
+++ b/lib/isodoc/jis/xref.rb
@@ -160,10 +160,11 @@ module IsoDoc
       end
 
       def commentary_name_anchors(clause, num, root, level)
+        t = clause_title(clause)
         @anchors[clause["id"]] =
           { label: num, xref: labelled_autonum(@labels["clause"], num),
             container: root,
-            title: clause_title(clause), level: level, type: "clause",
+            title: t && semx(clause, t, "title"), level: level, type: "clause",
             elem: @labels["clause"] }
       end
 


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/68

`commentary_name_anchors` stored the cross-reference title **bare** on the anchor, where base isodoc stores it **semx-wrapped**. `anchor_xref_full` emits the anchor title verbatim, so `full`/`title`-style cross-references dropped the `<semx element="title" source="…">` wrapper that top-level clauses keep — breaking downstream XSLT that keys off `semx[@element='title']`.

Wrap the title, matching base isodoc, guarded so title-less clauses stay `nil`. Subclause anchors inherit the same fix from `IsoDoc::Iso::Xref`.

🤖
