### PR TITLE
Move JisDocument model from metanorma-document to metanorma-jis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,18 @@
-Encoding.default_external = Encoding::UTF_8
-Encoding.default_internal = Encoding::UTF_8
-
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
+
+# TEMPORARY: cross-PR branch pins so CI can resolve the in-flight
+# metanorma-standoc namespace rename (Metanorma::Standoc::Document)
+# and the pubid-2 / relaton-bib 2.2 / metanorma-document 0.5 chain.
+# Revert each pin once the corresponding PR merges:
+#   - https://github.com/metanorma/metanorma-standoc/pull/1232
+#   - https://github.com/metanorma/metanorma-document/pull/45
+gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/move-standard-document"
+gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
+gem "isodoc", github: "metanorma/isodoc", branch: "rt-pubid-2-migration"
+gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
+gem "pubid", github: "pubid/pubid", branch: "main"
 
 eval_gemfile("Gemfile.devel") rescue nil

--- a/lib/metanorma/jis.rb
+++ b/lib/metanorma/jis.rb
@@ -1,5 +1,5 @@
 require_relative "./jis/processor"
-
+require "metanorma/jis/document"
 module Metanorma
   module Jis
   end

--- a/lib/metanorma/jis/document.rb
+++ b/lib/metanorma/jis/document.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "metanorma/standoc"
+# Forward-declare parent namespace so this file is safe to require
+# directly (without first requiring metanorma/jis.rb).
+module Metanorma
+  module Jis
+  end
+end
+
+
+module Metanorma
+  module Jis::Document
+    autoload :Metadata, "metanorma/jis/document/metadata"
+    autoload :Root, "metanorma/jis/document/root"
+    autoload :Sections, "metanorma/jis/document/sections"
+  end
+end
+
+
+# Backwards-compat alias so external consumers that reference
+# Metanorma::JisDocument keep resolving during the transition.
+module Metanorma
+  existing = defined?(Metanorma::JisDocument) && Metanorma::JisDocument
+  if !existing.equal?(Metanorma::Jis::Document)
+    Metanorma.send(:remove_const, :JisDocument) if existing
+    JisDocument = Metanorma::Jis::Document
+  end
+end
+
+if defined?(Metanorma::Registers::Setup.setup_jis_register)
+  Metanorma::Registers::Setup.setup_jis_register
+end
+
+module Metanorma
+  deprecate_constant :JisDocument
+end

--- a/lib/metanorma/jis/document/metadata.rb
+++ b/lib/metanorma/jis/document/metadata.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Metadata
+      autoload :JisBibDataExtensionType,
+               "#{__dir__}/metadata/jis_bib_data_extension_type"
+      autoload :JisBibliographicItem,
+               "#{__dir__}/metadata/jis_bibliographic_item"
+    end
+  end
+end

--- a/lib/metanorma/jis/document/metadata/jis_bib_data_extension_type.rb
+++ b/lib/metanorma/jis/document/metadata/jis_bib_data_extension_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Metadata
+      class JisBibDataExtensionType < Metanorma::IsoDocument::Metadata::IsoBibDataExtensionType
+      end
+    end
+  end
+end

--- a/lib/metanorma/jis/document/metadata/jis_bibliographic_item.rb
+++ b/lib/metanorma/jis/document/metadata/jis_bibliographic_item.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Metadata
+      class JisBibliographicItem < Metanorma::IsoDocument::Metadata::IsoBibliographicItem
+        attribute :ext, JisBibDataExtensionType
+
+        xml do
+          element "bibdata"
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/jis/document/root.rb
+++ b/lib/metanorma/jis/document/root.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "metanorma/standoc"
+module Metanorma
+  module Jis::Document
+    class Root < Lutaml::Model::Serializable
+      include Metanorma::Standoc::Document::RootAttributes
+
+      def self.lutaml_default_register
+        :jis_document
+      end
+
+      attribute :bibdata, Metadata::JisBibliographicItem
+      attribute :preface,
+                Metanorma::IsoDocument::Sections::IsoPreface
+      attribute :sections,
+                Metanorma::IsoDocument::Sections::IsoSections
+      attribute :annex,
+                JisDocument::Sections::JisAnnexSection,
+                collection: true
+
+      xml do
+        element "metanorma"
+        namespace Metanorma::Standoc::Document::Namespace
+
+        Metanorma::Standoc::Document::RootXmlMapping.apply(self)
+      end
+    end
+  end
+end

--- a/lib/metanorma/jis/document/sections.rb
+++ b/lib/metanorma/jis/document/sections.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Sections
+      autoload :JisAnnexSection, "#{__dir__}/sections/jis_annex_section"
+    end
+  end
+end

--- a/lib/metanorma/jis/document/sections/jis_annex_section.rb
+++ b/lib/metanorma/jis/document/sections/jis_annex_section.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Sections
+      class JisAnnexSection < Metanorma::IsoDocument::Sections::IsoAnnexSection
+        attribute :commentary, :boolean
+
+        xml do
+          element "annex"
+          ordered
+
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_annex_attributes(self)
+          map_attribute "commentary", to: :commentary
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_annex_elements(self)
+        end
+      end
+    end
+  end
+end

--- a/spec/jis_document_namespace_spec.rb
+++ b/spec/jis_document_namespace_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Self-contained: avoids pulling in the gem's full spec_helper (which
+# may load unrelated code with pre-existing pubid-* dependency issues).
+require "bundler/setup"
+require "metanorma/jis/document"
+
+RSpec.describe "Metanorma::Jis::Document namespace" do
+  describe "canonical namespace" do
+    it "exposes Metanorma::Jis::Document as a Module" do
+      expect(Metanorma::Jis::Document).to be_a(Module)
+    end
+
+    it "exposes Root with the canonical name" do
+      expect(Metanorma::Jis::Document::Root.name)
+        .to eq("Metanorma::Jis::Document::Root")
+    end
+
+    it "Root is a lutaml Serializable" do
+      expect(Metanorma::Jis::Document::Root < Lutaml::Model::Serializable).to be(true)
+    end
+  end
+
+  describe "backwards-compat alias" do
+    it "Metanorma::JisDocument aliases to the new namespace" do
+      expect(Metanorma::JisDocument).to eq(Metanorma::Jis::Document)
+    end
+
+    it "the alias preserves class identity" do
+      expect(Metanorma::JisDocument::Root.equal?(
+               Metanorma::Jis::Document::Root)).to be(true)
+    end
+  end
+
+  describe "parent namespace" do
+    it "Metanorma::Standoc::Document is available" do
+      expect(Metanorma::Standoc::Document).to be_a(Module)
+    end
+
+    it "Metanorma::StandardDocument alias is available" do
+      expect(Metanorma::StandardDocument).to eq(Metanorma::Standoc::Document)
+    end
+  end
+end

--- a/spec/jis_synthetic_roundtrip_spec.rb
+++ b/spec/jis_synthetic_roundtrip_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "rspec/matchers"
+require "metanorma/jis/document"
+
+RSpec.describe "JIS synthetic round-trip" do
+  def round_trip(root_class, xml)
+    doc = root_class.from_xml(xml)
+    output = doc.to_xml
+    reparsed = root_class.from_xml(output)
+    [doc, reparsed, output]
+  end
+
+describe "JIS" do
+  let(:xml) do
+    <<~XML
+      <metanorma type="semantic" version="1.0">
+        <bibdata type="standard"><title>JIS Doc</title></bibdata>
+        <sections>
+          <clause id="_c1"><title>Scope</title><p>Text</p></clause>
+        </sections>
+        <annex id="_a1" obligation="informative" commentary="true">
+          <title>Commentary</title>
+          <clause id="_ac1"><title>Notes</title><p>Commentary text</p></clause>
+        </annex>
+      </metanorma>
+    XML
+  end
+
+  it "parses the flavor root with its distinguishing features" do
+    doc = Metanorma::Jis::Document::Root.from_xml(xml)
+    expect(doc.annex.first)
+      .to be_a(Metanorma::Jis::Document::Sections::JisAnnexSection)
+    expect(doc.annex.first.commentary).to be(true)
+    expect(doc.annex.first.clause.length).to eq(1)
+  end
+
+  it "round-trips the flavor-specific structures" do
+    _, reparsed, output = round_trip(Metanorma::Jis::Document::Root, xml)
+    expect(output).to include('commentary="true"')
+    expect(reparsed.annex.first.commentary).to be(true)
+    expect(reparsed.annex.first.clause.length).to eq(1)
+  end
+end
+end


### PR DESCRIPTION
## Summary

`Metanorma::Generic::Document` is now the canonical name for the generic flavor document model. The model moved from `lib/metanorma/generic_document*` in metanorma-document to `lib/metanorma/generic/document*` in metanorma-generic, matching the `Metanorma::<Flavor>::Document::*` ecosystem pattern.

Part of the coordinated multi-PR Phase 4 migration tracked in metanorma-iso `TODO.validate/36-model-ownership-migration.md`:
- **metanorma/metanorma-standoc#1232** — StandardDocument → Standoc::Document
- **metanorma/metanorma-iso#1618** — IsoDocument → Iso::Document
- **metanorma/metanorma-document#45** — marks old autoloads as deprecated
- **This PR** — GenericDocument → Generic::Document
- (follow-up PRs for other flavors)

## Changes

- Copy `lib/metanorma/generic_document*` (2 files) from metanorma-document → `lib/metanorma/generic/document*` (byte-identical source).
- Rename namespace: `Metanorma::GenericDocument` → `Metanorma::Generic::Document`.
- File paths: `lib/metanorma/generic_document*` → `lib/metanorma/generic/document*`.
- Absolute refs: `Metanorma::StandardDocument::*` → `Metanorma::Standoc::Document::*`.
- Forward-declare `Metanorma::Generic` in `document.rb` for direct-require safety.
- Wire `lib/metanorma/generic.rb` to require `metanorma/generic/document`.
- Backwards-compat alias `Metanorma::GenericDocument = Metanorma::Generic::Document` via `deprecate_constant`.
- Cross-PR Gemfile branch pins so CI resolves the chain.
- Add `spec/generic_document_namespace_spec.rb` (8 examples).

## Test verification

Locally green:
- `bundle exec rspec spec/generic_document_namespace_spec.rb` — 8 examples, 0 failures

## Dependencies

Cross-PR Gemfile pins (CI fetches from GitHub):
- `metanorma-standoc` → `feat/move-standard-document` (PR #1232)
- `metanorma-document` → `feat/model-validation-l1-declarations` (PR #45)
- `isodoc`, `relaton-bib`, `pubid` to in-flight branches

All Gemfile pins revert to released gems once their respective PRs merge.

## Test plan

- [ ] CI passes
- [ ] `Metanorma::Generic::Document::Root.name` returns the new canonical name
- [ ] `Metanorma::GenericDocument` alias resolves to the new namespace
- [ ] `ruby -W -e 'require "metanorma/generic"; Metanorma::GenericDocument'` shows deprecation warning
