### PR TITLE
OCP adoption: model tree + core flavor table registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,10 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
 
+# TEMPORARY cross-PR pins (metanorma-core#18 wave)
+gem "metanorma-core", github: "metanorma/metanorma-core", branch: "feat/flavor-table"
+gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/move-standard-document"
+gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
+gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-validation-migration"
+
 eval_gemfile("Gemfile.devel") rescue nil

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,13 @@ gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/mo
 gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
 gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-validation-migration"
 
+# pubid-2 / relaton-bib 2.2 chain (isodoc PR#825)
+gem "isodoc",
+    github: "metanorma/isodoc",
+    branch: "rt-pubid-2-migration"
+gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
+gem "pubid",
+    github: "pubid/pubid",
+    branch: "main"
+
 eval_gemfile("Gemfile.devel") rescue nil

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-vali
 gem "isodoc",
     github: "metanorma/isodoc",
     branch: "rt-pubid-2-migration"
+gem "relaton-cli", ">= 2.2.0.pre.alpha.1"
 gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
 gem "pubid",
     github: "pubid/pubid",

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,4 @@ gem "isodoc",
     github: "metanorma/isodoc",
     branch: "rt-pubid-2-migration"
 gem "relaton-cli", ">= 3.0.0.pre.alpha.1"
-gem "pubid", ">= 2.0.0.pre.alpha.9"
+gem "pubid", "2.0.0.pre.alpha.8" # relaton 3.0.0.pre.alpha.1 pairs with pre-rename pubid; .alpha.9 renamed base_identifier->base

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
 
-# TEMPORARY cross-PR pins (metanorma-core#18 wave)
+# TEMPORARY cross-PR pins (metanorma-core#18 wave) — identical block in
+# every adoption PR; delete when the branches release.
 gem "metanorma-core", github: "metanorma/metanorma-core", branch: "feat/flavor-table"
 gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/move-standard-document"
 gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
@@ -21,5 +22,3 @@ gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
 gem "pubid",
     github: "pubid/pubid",
     branch: "main"
-
-eval_gemfile("Gemfile.devel") rescue nil

--- a/Gemfile
+++ b/Gemfile
@@ -13,12 +13,9 @@ gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/mo
 gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
 gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-validation-migration"
 
-# pubid-2 / relaton-bib 2.2 chain (isodoc PR#825)
+# relaton v3 monogem + pubid-2 prerelease chain (isodoc PR#825)
 gem "isodoc",
     github: "metanorma/isodoc",
     branch: "rt-pubid-2-migration"
-gem "relaton-cli", ">= 2.2.0.pre.alpha.1"
-gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
-gem "pubid",
-    github: "pubid/pubid",
-    branch: "main"
+gem "relaton-cli", ">= 3.0.0.pre.alpha.1"
+gem "pubid", ">= 2.0.0.pre.alpha.9"

--- a/lib/metanorma-jis.rb
+++ b/lib/metanorma-jis.rb
@@ -15,4 +15,3 @@ if defined? Metanorma::Registry
   require_relative "metanorma/jis"
   Metanorma::Registry.instance.register(Metanorma::Jis::Processor)
 end
-require "metanorma/jis/document"

--- a/lib/metanorma-jis.rb
+++ b/lib/metanorma-jis.rb
@@ -15,4 +15,4 @@ if defined? Metanorma::Registry
   require_relative "metanorma/jis"
   Metanorma::Registry.instance.register(Metanorma::Jis::Processor)
 end
-
+require "metanorma/jis/document"

--- a/lib/metanorma/jis.rb
+++ b/lib/metanorma/jis.rb
@@ -2,5 +2,6 @@ require_relative "./jis/processor"
 
 module Metanorma
   module Jis
+    autoload :Document, "metanorma/jis/document"
   end
 end

--- a/lib/metanorma/jis/document.rb
+++ b/lib/metanorma/jis/document.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "metanorma/standoc"
+module Metanorma
+  module Jis
+  end
+end
+
+module Metanorma
+  module Jis::Document
+  end
+end
+
+module Metanorma
+  existing = defined?(Metanorma::JisDocument) && Metanorma::JisDocument
+  if !existing.equal?(Metanorma::Jis::Document)
+    Metanorma.send(:remove_const, :JisDocument) if existing
+    JisDocument = Metanorma::Jis::Document
+  end
+end
+
+# OCP adoption: ONE registration in the metanorma-core flavor table
+require "metanorma-core"
+
+Metanorma::Core::Flavors.register(Metanorma::Core::Flavor.new(
+  name: :jis,
+  gem: "metanorma-jis",
+  model_root: Metanorma::Jis::Document::Root,
+  pubid_module: nil,
+  renderers: { html: Metanorma::Html::StandardRenderer },
+))

--- a/lib/metanorma/jis/document.rb
+++ b/lib/metanorma/jis/document.rb
@@ -1,24 +1,6 @@
 # frozen_string_literal: true
 
-require "metanorma/standoc"
-module Metanorma
-  module Jis
-  end
-end
-
-module Metanorma
-  module Jis::Document
-  end
-end
-
-module Metanorma
-  existing = defined?(Metanorma::JisDocument) && Metanorma::JisDocument
-  if !existing.equal?(Metanorma::Jis::Document)
-    Metanorma.send(:remove_const, :JisDocument) if existing
-    JisDocument = Metanorma::Jis::Document
-  end
-end
-
+require_relative "document/models"
 require "metanorma/jis/registers"
 Metanorma::Jis::Registers.setup
 
@@ -30,5 +12,7 @@ Metanorma::Core::Flavors.register(Metanorma::Core::Flavor.new(
   gem: "metanorma-jis",
   model_root: Metanorma::Jis::Document::Root,
   pubid_module: nil,
-  renderers: { html: Metanorma::Html::StandardRenderer },
+  renderers: { html: lambda do |_document, **_options|
+    Metanorma::Html::StandardRenderer
+  end },
 ))

--- a/lib/metanorma/jis/document.rb
+++ b/lib/metanorma/jis/document.rb
@@ -19,6 +19,9 @@ module Metanorma
   end
 end
 
+require "metanorma/jis/registers"
+Metanorma::Jis::Registers.setup
+
 # OCP adoption: ONE registration in the metanorma-core flavor table
 require "metanorma-core"
 

--- a/lib/metanorma/jis/document/metadata.rb
+++ b/lib/metanorma/jis/document/metadata.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Metadata
+      autoload :JisBibDataExtensionType,
+               "#{__dir__}/metadata/jis_bib_data_extension_type"
+      autoload :JisBibliographicItem,
+               "#{__dir__}/metadata/jis_bibliographic_item"
+    end
+  end
+end

--- a/lib/metanorma/jis/document/metadata/jis_bib_data_extension_type.rb
+++ b/lib/metanorma/jis/document/metadata/jis_bib_data_extension_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Metadata
+      class JisBibDataExtensionType < Metanorma::IsoDocument::Metadata::IsoBibDataExtensionType
+      end
+    end
+  end
+end

--- a/lib/metanorma/jis/document/metadata/jis_bibliographic_item.rb
+++ b/lib/metanorma/jis/document/metadata/jis_bibliographic_item.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Metadata
+      class JisBibliographicItem < Metanorma::IsoDocument::Metadata::IsoBibliographicItem
+        attribute :ext, JisBibDataExtensionType
+
+        xml do
+          element "bibdata"
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/jis/document/models.rb
+++ b/lib/metanorma/jis/document/models.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "metanorma/standoc"
+require "metanorma/iso/document/models"
+module Metanorma
+  module Jis
+  end
+end
+
+module Metanorma
+  module Jis::Document
+    autoload :Metadata, "metanorma/jis/document/metadata"
+    autoload :Root, "metanorma/jis/document/root"
+    autoload :Sections, "metanorma/jis/document/sections"
+  end
+end
+
+module Metanorma
+  existing = defined?(Metanorma::JisDocument) && Metanorma::JisDocument
+  if !existing.equal?(Metanorma::Jis::Document)
+    Metanorma.send(:remove_const, :JisDocument) if existing
+    JisDocument = Metanorma::Jis::Document
+  end
+end

--- a/lib/metanorma/jis/document/root.rb
+++ b/lib/metanorma/jis/document/root.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    class Root < Lutaml::Model::Serializable
+      include Metanorma::StandardDocument::RootAttributes
+
+      def self.lutaml_default_register
+        :jis_document
+      end
+
+      attribute :bibdata, Metadata::JisBibliographicItem
+      attribute :preface,
+                Metanorma::IsoDocument::Sections::IsoPreface
+      attribute :sections,
+                Metanorma::IsoDocument::Sections::IsoSections
+      attribute :annex,
+                JisDocument::Sections::JisAnnexSection,
+                collection: true
+
+      xml do
+        element "metanorma"
+        namespace Metanorma::StandardDocument::Namespace
+
+        Metanorma::StandardDocument::RootXmlMapping.apply(self)
+      end
+    end
+  end
+end

--- a/lib/metanorma/jis/document/root.rb
+++ b/lib/metanorma/jis/document/root.rb
@@ -3,7 +3,7 @@
 module Metanorma
   module Jis::Document
     class Root < Lutaml::Model::Serializable
-      include Metanorma::StandardDocument::RootAttributes
+      include Metanorma::Standoc::Document::RootAttributes
 
       def self.lutaml_default_register
         :jis_document
@@ -20,9 +20,9 @@ module Metanorma
 
       xml do
         element "metanorma"
-        namespace Metanorma::StandardDocument::Namespace
+        namespace Metanorma::Standoc::Document::Namespace
 
-        Metanorma::StandardDocument::RootXmlMapping.apply(self)
+        Metanorma::Standoc::Document::RootXmlMapping.apply(self)
       end
     end
   end

--- a/lib/metanorma/jis/document/sections.rb
+++ b/lib/metanorma/jis/document/sections.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Sections
+      autoload :JisAnnexSection, "#{__dir__}/sections/jis_annex_section"
+    end
+  end
+end

--- a/lib/metanorma/jis/document/sections/jis_annex_section.rb
+++ b/lib/metanorma/jis/document/sections/jis_annex_section.rb
@@ -10,9 +10,9 @@ module Metanorma
           element "annex"
           ordered
 
-          Metanorma::StandardDocument::SectionXmlMapping.apply_annex_attributes(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_annex_attributes(self)
           map_attribute "commentary", to: :commentary
-          Metanorma::StandardDocument::SectionXmlMapping.apply_annex_elements(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_annex_elements(self)
         end
       end
     end

--- a/lib/metanorma/jis/document/sections/jis_annex_section.rb
+++ b/lib/metanorma/jis/document/sections/jis_annex_section.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Jis::Document
+    module Sections
+      class JisAnnexSection < Metanorma::IsoDocument::Sections::IsoAnnexSection
+        attribute :commentary, :boolean
+
+        xml do
+          element "annex"
+          ordered
+
+          Metanorma::StandardDocument::SectionXmlMapping.apply_annex_attributes(self)
+          map_attribute "commentary", to: :commentary
+          Metanorma::StandardDocument::SectionXmlMapping.apply_annex_elements(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/jis/front.rb
+++ b/lib/metanorma/jis/front.rb
@@ -1,4 +1,4 @@
-require "pubid-jis"
+require "pubid/jis"
 
 module Metanorma
   module Jis

--- a/lib/metanorma/jis/registers.rb
+++ b/lib/metanorma/jis/registers.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Metanorma
+  module Jis
+    # jis's lutaml-model register: type substitutions from standoc.
+    # Formerly Metanorma::Registers::Setup.setup_jis_register in metanorma-document.
+    module Registers
+      module_function
+
+      def setup
+          iso = Metanorma::IsoDocument
+          reg = Lutaml::Model::Register.new(:jis_document,
+                                            fallback: [:iso_document])
+          Lutaml::Model::GlobalRegister.register(reg)
+
+          reg.register_global_type_substitution(
+            from_type: iso::Sections::IsoAnnexSection,
+            to_type: Metanorma::Jis::Document::Sections::JisAnnexSection,
+          )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Model tree extracted from metanorma-document@main and registered with the metanorma-core flavor table (metanorma-core#18). One entry: model_root, renderer, pubid. Part of the full-OCP restructure wave.